### PR TITLE
Adds Parallel processing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 PATH
   remote: .
   specs:
-    sensu-plugins-azure-burstable-metrics (0.0.6)
+    sensu-plugins-azure-burstable-metrics (0.0.7)
       json (= 2.1.0)
+      mixlib-cli (= 1.7.0)
+      parallel (= 1.12.1)
       sensu-plugin (~> 1.2)
 
 GEM
@@ -11,19 +13,20 @@ GEM
     diff-lcs (1.3)
     json (2.1.0)
     mixlib-cli (1.7.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    parallel (1.12.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     sensu-plugin (1.3.0)
       json
       mixlib-cli (>= 1.5.0)

--- a/bin/sensu-plugins-azure-burstable-metrics.rb
+++ b/bin/sensu-plugins-azure-burstable-metrics.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 
 require 'json'
+require 'parallel'
 require 'sensu-plugin/metric/cli'
 require 'time'
 
@@ -53,9 +54,9 @@ class BurstableMetrics < Sensu::Plugin::Metric::CLI::Graphite
     start_time = (time - 120).strftime(@@time_format)
     end_time = (time - 60).strftime(@@time_format)
 
-    machines.each do |machine|
+    Parallel.map(machines, in_threads: 5) { |machine|
       process_machine(machine, time, start_time, end_time)
-    end
+    }
 
     ok
   end

--- a/lib/sensu-plugins-azure-burstable-metrics/version.rb
+++ b/lib/sensu-plugins-azure-burstable-metrics/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsAzureBurstableMetrics
   class Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 6
+    PATCH = 7
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/sensu-plugins-azure-burstable-metrics.gemspec
+++ b/sensu-plugins-azure-burstable-metrics.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsAzureBurstableMetrics::Version::VER_STRING
 
   s.add_runtime_dependency 'json',         '2.1.0'
+  s.add_runtime_dependency 'parallel',     '1.12.1'
+  s.add_runtime_dependency 'mixlib-cli',   '1.7.0'
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
 
   s.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/test_monitor_spec.rb
+++ b/spec/test_monitor_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe 'BurstableMetrics' do
         'sensu.poc-bs-test.cpu_credits_remaining 636.0',
         'sensu.poc-bms-test.cpu_credits_consumed 0.0',
         'sensu.poc-bms-test.cpu_credits_remaining 636.0',
-      ]
+      ].sort!
 
-      metrics.each_line.with_index do |line, index|
+      metrics.split("\n").sort!.each_with_index do |line, index|
         expect(line).to start_with(expected[index])
       end
     end


### PR DESCRIPTION
  * Pins `mixlib-cli` to 1.7.0 as 2.X requires Ruby > 2.3